### PR TITLE
Add update the kernel package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ForemanKernelCare
 
-This plugin removes kernel [trace](https://theforeman.org/plugins/katello/3.18/user_guide/tracer/index.html) if [KernelCare](https://www.kernelcare.com/product/) package is installed on host
+This plugin removes kernel [trace](https://theforeman.org/plugins/katello/nightly/user_guide/tracer/index.html) and update the kernel package version if [KernelCare](https://www.kernelcare.com/product/) package is installed on host
 
 ## Installation
 
-See [How_to_Install_a_Plugin](http://projects.theforeman.org/projects/foreman/wiki/How_to_Install_a_Plugin)
+See [How_to_Install_a_Plugin](https://www.theforeman.org/plugins/#2.Installation)
 for how to install Foreman plugins
 
 ## Usage
@@ -17,7 +17,7 @@ Fork and send a Pull Request. Thanks!
 
 ## Copyright
 
-Copyright (c) 2021 maccelf
+Copyright (c) 2022 maccelf
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/app/controllers/concerns/foreman_kernel_care/foreman_tasks.rb
+++ b/app/controllers/concerns/foreman_kernel_care/foreman_tasks.rb
@@ -1,0 +1,22 @@
+module ForemanKernelCare
+  module ForemanTasks
+    def callback
+      callbacks = params.key?(:callback) ? Array(params) : params[:callbacks]
+      ids = callbacks.map { |payload| payload[:callback][:task_id] }
+      foreman_tasks = ::ForemanTasks::Task.where(:id => ids)
+      external_map = Hash[*foreman_tasks.pluck(:id, :external_id).flatten]
+      callbacks.each do |payload|
+        # We need to call .to_unsafe_h to unwrap the hash from ActionController::Parameters
+        callback = payload[:callback]
+        foreman_task = foreman_tasks.find { |task| task.id == callback[:task_id] }
+        if foreman_task.action.include?('Get patched kernel version')
+          version, release = payload[:data].to_unsafe_h['result'].first['output'].strip.split('-')
+          job_invocation = ::JobInvocation.where(:task_id => foreman_task.parent_task_id).first
+          job_invocation.targeting.hosts.each { |host| host.update_kernel_version(version, release) }
+        end
+        process_callback(external_map[callback[:task_id]], callback[:step_id].to_i, payload[:data].to_unsafe_h, :request_id => ::Logging.mdc['request'])
+      end
+      render :json => { :message => 'processing' }.to_json
+    end
+  end
+end

--- a/app/models/concerns/foreman_kernel_care/host_managed_extensions.rb
+++ b/app/models/concerns/foreman_kernel_care/host_managed_extensions.rb
@@ -31,6 +31,44 @@ module ForemanKernelCare
       update_trace_status
     end
 
+    def update_kernel_version(version, release)
+      packages = ::Katello::InstalledPackage.where('name LIKE ?', '%kernel%').where.not(name: 'kernelcare').to_a
+      delete_ids = []
+      simple_packages = packages.map do |p|
+        delete_ids << p.id
+        ::Katello::Pulp::SimplePackage.new({
+                                             arch: p.arch,
+                                             epoch: p.epoch,
+                                             version: version,
+                                             release: release,
+                                             name: p.name
+                                           })
+      end
+      found = import_package_profile_in_bulk(simple_packages)
+      sync_kernel_associations(found.map(&:id).uniq, delete_ids)
+    end
+
+    def sync_kernel_associations(new_patched_kernel_ids, delete_ids)
+      ::Katello::Util::Support.active_record_retry do
+        table_name = host_installed_packages.table_name
+
+        queries = []
+
+        if delete_ids.any?
+          queries << "DELETE FROM #{table_name} WHERE host_id=#{id} AND installed_package_id IN (#{delete_ids.join(', ')})"
+        end
+
+        unless new_patched_kernel_ids.empty?
+          inserts = new_patched_kernel_ids.map { |unit_id| "(#{unit_id.to_i}, #{id.to_i})" }
+          queries << "INSERT INTO #{table_name} (installed_package_id, host_id) VALUES #{inserts.join(', ')}"
+        end
+
+        queries.each do |query|
+          ::ActiveRecord::Base.connection.execute(query)
+        end
+      end
+    end
+
     protected
 
     def kernelcare?

--- a/app/models/concerns/foreman_kernel_care/host_managed_extensions.rb
+++ b/app/models/concerns/foreman_kernel_care/host_managed_extensions.rb
@@ -1,5 +1,16 @@
 module ForemanKernelCare
   module HostManagedExtensions
+    def import_package_profile(simple_packages)
+      if kernelcare?
+        composer = ::JobInvocationComposer.for_feature(:kernel_version, self)
+        composer.triggering.mode = :future
+        composer.trigger!
+      end
+
+      found = import_package_profile_in_bulk(simple_packages)
+      sync_package_associations(found.map(&:id).uniq)
+    end
+
     def import_tracer_profile(tracer_profile)
       traces = []
       tracer_profile.each do |trace, attributes|

--- a/app/views/foreman_kernel_care/job_templates/kernel_version.erb
+++ b/app/views/foreman_kernel_care/job_templates/kernel_version.erb
@@ -7,4 +7,9 @@ description_format: "Get patched kernel version"
 provider_type: SSH
 feature: kernel_version
 %>
-/usr/bin/kcare-uname -r
+<%
+  unless @host.installed_packages.select { |package| package.name == 'kernelcare' }.empty?
+    render_error(N_('Unsupported host.'))
+  end
+%>
+/usr/bin/kcarectl --uname

--- a/app/views/foreman_kernel_care/job_templates/kernel_version.erb
+++ b/app/views/foreman_kernel_care/job_templates/kernel_version.erb
@@ -1,0 +1,10 @@
+<%#
+kind: job_template
+name: Kernel version
+model: JobTemplate
+job_category: Commands
+description_format: "Get patched kernel version"
+provider_type: SSH
+feature: kernel_version
+%>
+/usr/bin/kcare-uname -r

--- a/db/seeds.d/100_assign_features_with_templates.rb
+++ b/db/seeds.d/100_assign_features_with_templates.rb
@@ -16,6 +16,13 @@ User.as_anonymous_admin do
         module_template.organizations << Organization.unscoped.all if module_template.organizations.empty?
         module_template.locations << Location.unscoped.all if module_template.locations.empty?
       end
+
+      module_template = JobTemplate.find_by(name: 'Kernel version')
+      if module_template && !Rails.env.test? && Setting[:remote_execution_sync_templates]
+        module_template.sync_feature('kernel_version')
+        module_template.organizations << Organization.unscoped.all if module_template.organizations.empty?
+        module_template.locations << Location.unscoped.all if module_template.locations.empty?
+      end
     end
   end
 end

--- a/foreman_kernel_care.gemspec
+++ b/foreman_kernel_care.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,db,lib}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'katello', '>= 3.8.0'
   s.add_dependency 'foreman_remote_execution', '>= 1.5.6'
+  s.add_dependency 'katello', '>= 3.8.0'
 
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'rubocop'

--- a/lib/foreman_kernel_care/engine.rb
+++ b/lib/foreman_kernel_care/engine.rb
@@ -19,6 +19,7 @@ module ForemanKernelCare
     # Include concerns in this config.to_prepare block
     config.to_prepare do
       Katello::Concerns::HostManagedExtensions.prepend ForemanKernelCare::HostManagedExtensions
+      ForemanTasks::Api::TasksController.prepend ForemanKernelCare::ForemanTasks
     rescue StandardError => e
       Rails.logger.warn "ForemanKernelCare: skipping engine hook (#{e})"
     end

--- a/lib/foreman_kernel_care/remote_execution.rb
+++ b/lib/foreman_kernel_care/remote_execution.rb
@@ -11,6 +11,12 @@ module ForemanKernelCare
         N_('Run Update kernel'),
         :description => N_('Runs Update kernel')
       )
+
+      RemoteExecutionFeature.register(
+        :kernel_version,
+        N_('Get patched kernel version'),
+        :description => N_('Get patched kernel version')
+      )
     end
   end
 end


### PR DESCRIPTION
  - Add new seeds for the template "kernel_version"
  - Add new template "kernel version" to run the command `kcarectl --uname`
  - Add run job template "kernel_version" on host when import package profile
  - Override import package method
  - Override callback method for ForemanTasks