### PR TITLE
Fix SafeMode rendering-error in kernel version job

### DIFF
--- a/app/views/foreman_kernel_care/job_templates/kernel_version.erb
+++ b/app/views/foreman_kernel_care/job_templates/kernel_version.erb
@@ -8,7 +8,7 @@ provider_type: SSH
 feature: kernel_version
 %>
 <%
-  unless @host.installed_packages.select { |package| package.name == 'kernelcare' }.empty?
+  unless @host.installed_packages.map{ |package| package.name }.include?('kernelcare')
     render_error(N_('Unsupported host.'))
   end
 %>


### PR DESCRIPTION
Tested with foreman-3.1 and got a SafeMode-error because of the `select()`.
Changing to `map().include?()` solved it for me.