### PR TITLE
Fix the way KernelCare plugin overrides the HostManagedExtension

### DIFF
--- a/lib/foreman_kernel_care/engine.rb
+++ b/lib/foreman_kernel_care/engine.rb
@@ -1,3 +1,5 @@
+require 'katello'
+require 'foreman_tasks'
 require 'foreman_kernel_care/remote_execution'
 
 module ForemanKernelCare
@@ -10,18 +12,14 @@ module ForemanKernelCare
     initializer 'foreman_kernel_care.register_plugin', :before => :finisher_hook do |_app|
       Foreman::Plugin.register :foreman_kernel_care do
         requires_foreman '>= 1.19.0'
-
-        # Add a new role called 'Discovery' if it doesn't exist
         role 'Foreman KernelCare', [:view_job_templates]
       end
     end
 
-    # Include concerns in this config.to_prepare block
-    config.to_prepare do
-      Katello::Concerns::HostManagedExtensions.prepend ForemanKernelCare::HostManagedExtensions
-      ForemanTasks::Api::TasksController.prepend ForemanKernelCare::ForemanTasks
-    rescue StandardError => e
-      Rails.logger.warn "ForemanKernelCare: skipping engine hook (#{e})"
+    # make sure the plugin is initialized before katello loads the host extensions
+    initializer 'foreman_kernel_care.load_kernelcare_override', :before => :finisher_hook, :after => [ 'katello.register_plugin', 'foreman_tasks.register_plugin' ] do
+      ::Katello::Concerns::HostManagedExtensions.prepend ForemanKernelCare::HostManagedExtensions
+      ::ForemanTasks::Api::TasksController.prepend ForemanKernelCare::ForemanTasks
     end
 
     rake_tasks do


### PR DESCRIPTION
With the previous implementation, it may happen, that the KernelCare overrids for Katello were loaded to late. The result was, that methods like kernelcare? did not exist for the host.