### PR TITLE
Add new job template to view newest available patch

### DIFF
--- a/app/views/foreman_kernel_care/job_templates/view_newest_patch.erb
+++ b/app/views/foreman_kernel_care/job_templates/view_newest_patch.erb
@@ -1,0 +1,16 @@
+<%#
+kind: job_template
+name: LivePatching - Kernel version
+model: JobTemplate
+job_category: LivePatching - Script Default
+description_format: "Get patched kernel version"
+provider_type: script
+feature: kernel_version
+%>
+<%
+  unless @host.installed_packages.map{ |package| package.name }.include?('kernelcare') || @host.installed_debs.map{ |package| package.name }.include?('kernelcare')
+    render_error(N_('Unsupported host.'))
+  end
+%>
+
+/usr/bin/kcarectl --latest-patch-info --json


### PR DESCRIPTION
Job template to view the patches that are available to be installed. 

It might make sense to clean the templates up a bit and create a job template that executes kernelcare commands  and call this template from other templates. 