### PR TITLE
Add more descriptive error message

### DIFF
--- a/app/views/foreman_kernel_care/job_templates/kernel_version.erb
+++ b/app/views/foreman_kernel_care/job_templates/kernel_version.erb
@@ -9,7 +9,7 @@ feature: kernel_version
 %>
 <%
   unless @host.installed_packages.map{ |package| package.name }.include?('kernelcare') || @host.installed_debs.map{ |package| package.name }.include?('kernelcare')
-    render_error(N_('Unsupported host.'))
+    render_error(N_('The "kernelcare" package is not installed on your managed host which is required by this job template.'))
   end
 %>
 

--- a/app/views/foreman_kernel_care/job_templates/update_kernel.erb
+++ b/app/views/foreman_kernel_care/job_templates/update_kernel.erb
@@ -10,7 +10,7 @@ feature: update_kernel
 
 <%
   unless @host.installed_packages.map{ |package| package.name }.include?('kernelcare') || @host.installed_debs.map{ |package| package.name }.include?('kernelcare')
-    render_error(N_('Unsupported host.'))
+    render_error(N_('The "kernelcare" package is not installed on your managed host which is required by this job template.'))
   end
 %>
 

--- a/app/views/foreman_kernel_care/job_templates/view_newest_patch.erb
+++ b/app/views/foreman_kernel_care/job_templates/view_newest_patch.erb
@@ -8,7 +8,7 @@ provider_type: script
 %>
 <%
   unless @host.installed_packages.map{ |package| package.name }.include?('kernelcare') || @host.installed_debs.map{ |package| package.name }.include?('kernelcare')
-    render_error(N_('Unsupported host.'))
+    render_error(N_('The "kernelcare" package is not installed on your managed host which is required by this job template.'))
   end
 %>
 


### PR DESCRIPTION
I have reworded the error message that is shown in Foreman if you try to run this job template on a managed hosts that does not have the "kernelcare" package installed.

![Screenshot from 2023-10-13 14-34-38](https://github.com/maccelf/foreman_kernel_care/assets/12595287/eaa816bd-e9c1-400b-b622-5888fa3c9bcf)

cc @nadjaheitmann 